### PR TITLE
Rename State.config to State.widget

### DIFF
--- a/lib/reddit_home.dart
+++ b/lib/reddit_home.dart
@@ -24,7 +24,7 @@ class RedditHomeState extends State<RedditHome> {
         ),
         body: new MaterialList<Reddit>(
             type: MaterialListType.oneLineWithAvatar,
-            items: config.reddits,
+            items: widget.reddits,
             itemBuilder: (BuildContext context, Reddit reddit, int index) {
               return new RedditRow(
                   reddit: reddit


### PR DESCRIPTION
We're renamed State.config getter in https://github.com/flutter/flutter/issues/7015